### PR TITLE
Check for files, not versions, looking for Firefox in Ubuntu

### DIFF
--- a/fuckForticlient.sh
+++ b/fuckForticlient.sh
@@ -168,16 +168,13 @@ getProfilePath(){
 			profilepath="${HOME}/.mozilla/firefox"
 			;;
 		Ubuntu)
-			if [ "$DISTROV" != "20.04" ]; then
-				if [ ! -d ${HOME}/snap/firefox/common/.mozilla/firefox ]; then
-					return -1
-				fi
+			# Ubuntu can be snap or usual path. Check for files, not versions
+			if [ -d ${HOME}/snap/firefox/common/.mozilla/firefox ]; then
 				profilepath="${HOME}/snap/firefox/common/.mozilla/firefox"
-			else
-				if [ ! -d ${HOME}/.mozilla/firefox ]; then
-					return -1
-				fi
+			elif [ -d ${HOME}/.mozilla/firefox ]; then
 				profilepath="${HOME}/.mozilla/firefox"
+			else 
+				return -1
 			fi
 			;;
 		*)


### PR DESCRIPTION
Snap is the default option for Firefox in Ubuntu, but can also be installed as regular .deb package (reason in my case: it's the only way that DNIe works). It's better to check first for the snap files, then the files in the usual place and if none of them exists, then fail.